### PR TITLE
5.12 Вёрстка экрана с началом игры

### DIFF
--- a/packages/client/src/components/Modal.tsx
+++ b/packages/client/src/components/Modal.tsx
@@ -1,0 +1,23 @@
+import { type FC, type ReactNode } from 'react';
+import { BTN_CLASS, BTN_GROUP_CLASS, FORM_CONTAINER_CLASS, FORM_TITLE_CLASS } from '../constants/style-groups';
+
+type ModalProps = {
+  title: string;
+  onClose: () => void;
+  children?: ReactNode;
+  closeLabel?: string;
+};
+
+export const Modal: FC<ModalProps> = ({ title, onClose, children, closeLabel = 'Закрыть' }) => (
+  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+    <div className={`${FORM_CONTAINER_CLASS} max-w-lg`} onClick={e => e.stopPropagation()}>
+      <h2 className={FORM_TITLE_CLASS}>{title}</h2>
+      {children}
+      <div className={BTN_GROUP_CLASS}>
+        <button className={BTN_CLASS} onClick={onClose}>
+          {closeLabel}
+        </button>
+      </div>
+    </div>
+  </div>
+);

--- a/packages/client/src/constants/style-groups.ts
+++ b/packages/client/src/constants/style-groups.ts
@@ -11,6 +11,14 @@ export const BTN_GROUP_CLASS =
   'mt-10 flex flex-col justify-center items-center';
 export const BTN_CLASS =
   'shadow-md max-w-60 w-full text-main-white p-2 border border-btn-light rounded-main-radius bg-btn-light mb-6 last:mb-0 dark:text-main-white dark:bg-btn-dark dark:border-btn-dark';
+export const COUNTER_BTN_CLASS =
+  'w-8 h-8 rounded-full border border-btn-light bg-btn-light text-main-white dark:bg-btn-dark dark:border-btn-dark disabled:opacity-40';
+export const TOGGLE_BTN_BASE_CLASS =
+  'flex-1 p-2 border rounded-main-radius font-bold transition-colors';
+export const TOGGLE_BTN_ACTIVE_CLASS =
+  'bg-btn-light text-main-white border-btn-light dark:bg-btn-dark dark:border-btn-dark';
+export const TOGGLE_BTN_INACTIVE_CLASS =
+  'bg-transparent text-main-blue border-btn-light dark:text-main-white dark:border-btn-dark';
 export const TITLE_CLASS = 'font-bold text-main-blue dark:text-main-white';
 export const APP_TITLE_CLASS = `${TITLE_CLASS} text-5xl mb-12`;
 export const FORM_TITLE_CLASS = `${TITLE_CLASS} text-3xl mb-8 `;

--- a/packages/client/src/pages/game/GamePage.tsx
+++ b/packages/client/src/pages/game/GamePage.tsx
@@ -1,5 +1,6 @@
 import { type FC, useState } from 'react';
 import { GameStartScreen } from './GameStartScreen';
+import { DEFAULT_GAME_CONFIG, type GameConfig } from './types';
 
 enum GameState {
   Start = 'start',
@@ -9,13 +10,19 @@ enum GameState {
 
 export const GamePage: FC = () => {
   const [gameState, setGameState] = useState<GameState>(GameState.Start);
+  const [gameConfig, setGameConfig] = useState<GameConfig>(DEFAULT_GAME_CONFIG);
+
+  const handleStart = (config: GameConfig) => {
+    setGameConfig(config);
+    setGameState(GameState.Playing);
+  };
 
   if (gameState === GameState.Start) {
-    return <GameStartScreen onStart={() => setGameState(GameState.Playing)} />;
+    return <GameStartScreen onStart={handleStart} />;
   }
 
   if (gameState === GameState.Playing) {
-    return <div>TODO: Canvas</div>;
+    return <div>TODO: Canvas (config: {JSON.stringify(gameConfig)})</div>;
   }
 
   if (gameState === GameState.Finished) {

--- a/packages/client/src/pages/game/GameStartScreen.tsx
+++ b/packages/client/src/pages/game/GameStartScreen.tsx
@@ -1,26 +1,66 @@
 import { type FC, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   APP_TITLE_CLASS,
   BTN_CLASS,
   BTN_GROUP_CLASS,
+  COUNTER_BTN_CLASS,
   FORM_CONTAINER_CLASS,
   FORM_PAGE_CONTAINER_CLASS,
-  FORM_TITLE_CLASS,
+  TITLE_CLASS,
+  TOGGLE_BTN_ACTIVE_CLASS,
+  TOGGLE_BTN_BASE_CLASS,
+  TOGGLE_BTN_INACTIVE_CLASS,
 } from '../../constants/style-groups';
+import { MAX_PLAYERS, MIN_PLAYERS, PlayerType, type GameConfig } from './types';
+import { Modal } from '../../components/Modal';
+import { ROUTES } from '../../routes';
+
+const PLAYER_TYPE_LABELS: Record<PlayerType, string> = {
+  [PlayerType.Human]: 'Человек',
+  [PlayerType.Computer]: 'Компьютер',
+};
 
 type GameStartScreenProps = {
-  onStart: () => void;
+  onStart: (config: GameConfig) => void;
 };
 
 export const GameStartScreen: FC<GameStartScreenProps> = ({ onStart }) => {
+  const navigate = useNavigate();
   const [isRulesOpen, setIsRulesOpen] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [playerType, setPlayerType] = useState<PlayerType>(PlayerType.Computer);
+  const [playerCount, setPlayerCount] = useState(MIN_PLAYERS);
+
+  const handlePlayerCountChange = (delta: number) => {
+    const next = playerCount + delta;
+    if (next >= MIN_PLAYERS && next <= MAX_PLAYERS) {
+      setPlayerCount(next);
+    }
+  };
+
+  const handleStart = () => {
+    const config: GameConfig = {
+      playerType,
+      playerCount: playerType === PlayerType.Human ? 1 : playerCount,
+    };
+    onStart(config);
+  };
 
   return (
     <div className={FORM_PAGE_CONTAINER_CLASS}>
       <div className={FORM_CONTAINER_CLASS}>
+        <div className="w-full flex justify-start absolute pl-8 pr-8 top-12 left-0">
+          <button onClick={() => navigate(ROUTES.main)}>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <title>Arrow-back SVG Icon</title>
+              <path className="fill-path-light dark:fill-path-dark" d="M21 11H6.414l5.293-5.293l-1.414-1.414L2.586 12l7.707 7.707l1.414-1.414L6.414 13H21z"/>
+            </svg>
+          </button>
+        </div>
         <h1 className={APP_TITLE_CLASS}>Flip 7</h1>
         <div className={BTN_GROUP_CLASS}>
-          <button className={BTN_CLASS} onClick={onStart}>
+          <button className={BTN_CLASS} onClick={() => setIsSettingsOpen(true)}>
             Начать игру
           </button>
           <button className={BTN_CLASS} onClick={() => setIsRulesOpen(true)}>
@@ -29,24 +69,55 @@ export const GameStartScreen: FC<GameStartScreenProps> = ({ onStart }) => {
         </div>
       </div>
 
-      {isRulesOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          onClick={() => setIsRulesOpen(false)}>
-          <div
-            className={`${FORM_CONTAINER_CLASS} max-w-lg`}
-            onClick={e => e.stopPropagation()}>
-            <h2 className={FORM_TITLE_CLASS}>Правила игры</h2>
-            {/* TODO: Добавить правила */}
-            <div className={BTN_GROUP_CLASS}>
-              <button
-                className={BTN_CLASS}
-                onClick={() => setIsRulesOpen(false)}>
-                Закрыть
-              </button>
+      {isSettingsOpen && (
+        <Modal title="Настройки игры" onClose={() => setIsSettingsOpen(false)} closeLabel="Отмена">
+          <div className="flex flex-col gap-6 w-full mb-6">
+            <div className="flex flex-col gap-2 items-center">
+              <span className={`${TITLE_CLASS} text-center`}>Игроки</span>
+              <div className="flex gap-2 w-full">
+                {[PlayerType.Computer, PlayerType.Human].map(type => (
+                  <button
+                    key={type}
+                    className={`${TOGGLE_BTN_BASE_CLASS} ${playerType === type ? TOGGLE_BTN_ACTIVE_CLASS : TOGGLE_BTN_INACTIVE_CLASS}`}
+                    onClick={() => setPlayerType(type)}>
+                    {PLAYER_TYPE_LABELS[type]}
+                  </button>
+                ))}
+              </div>
             </div>
+
+            {playerType === PlayerType.Computer && (
+              <div className="flex flex-col gap-2 items-center">
+                <span className={`${TITLE_CLASS} text-center`}>Количество игроков</span>
+                <div className="flex items-center gap-4">
+                  <button
+                    className={COUNTER_BTN_CLASS}
+                    onClick={() => handlePlayerCountChange(-1)}
+                    disabled={playerCount <= MIN_PLAYERS}>
+                    −
+                  </button>
+                  <span className={`${TITLE_CLASS} text-xl w-4 text-center`}>
+                    {playerCount}
+                  </span>
+                  <button
+                    className={COUNTER_BTN_CLASS}
+                    onClick={() => handlePlayerCountChange(1)}
+                    disabled={playerCount >= MAX_PLAYERS}>
+                    +
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
-        </div>
+
+          <button className={BTN_CLASS} onClick={handleStart}>
+            Начать игру
+          </button>
+        </Modal>
+      )}
+
+      {isRulesOpen && (
+        <Modal title="Правила игры" onClose={() => setIsRulesOpen(false)} />
       )}
     </div>
   );

--- a/packages/client/src/pages/game/types.ts
+++ b/packages/client/src/pages/game/types.ts
@@ -1,0 +1,17 @@
+export enum PlayerType {
+  Computer = 'computer',
+  Human = 'human',
+}
+
+export type GameConfig = {
+  playerType: PlayerType;
+  playerCount: number;
+};
+
+export const MIN_PLAYERS = 2;
+export const MAX_PLAYERS = 8;
+
+export const DEFAULT_GAME_CONFIG: GameConfig = {
+  playerType: PlayerType.Computer,
+  playerCount: MIN_PLAYERS,
+};


### PR DESCRIPTION
### Какую задачу решаем
Задача https://github.com/Alexey6486/58_mf_teamwork_02/issues/12

В ПР https://github.com/Alexey6486/58_mf_teamwork_02/pull/25 добавил:
- роут /game и GamePage с тремя состояниями (Start, Playing, Finished), реализован экран начала игры (GameStartScreen) с кнопками «Начать игру» и «Правила» (модалка) 

В текущем ПР добавил модалку с настройками игры перед началом игры

### Скриншоты/видяшка (если есть)
<img width="3324" height="1790" alt="image" src="https://github.com/user-attachments/assets/9d541008-ce1e-4173-8e19-2c45b5b80687" />
<img width="3324" height="1790" alt="image" src="https://github.com/user-attachments/assets/3f3b8d48-b522-43b5-9cb9-53e9801b1eb4" />
<img width="3324" height="1790" alt="image" src="https://github.com/user-attachments/assets/85c2e9d7-c449-4593-b651-21ee73b46d33" />

### TBD (если есть)
Добавить логику и Canvas для состояния Playing
Добавить экран завершения игры для состояния Finished
Добавить текст правил игры в модалку «Правила игры»